### PR TITLE
feat: Generate commit message for `git commit -m`

### DIFF
--- a/src/toml.rs
+++ b/src/toml.rs
@@ -74,7 +74,6 @@ the-force = { value = "surrounds-you" }
             "file_ignore",
             "model_provider",
             "openai.api_base",
-            "openai.api_key",
             "openai.model",
             "openai.proxy",
             "openai.retries",


### PR DESCRIPTION
This change modifies the `prepare-commit-msg` hook to generate a commit message when using `git commit -m`. The message you provide is prepended to the generated message.